### PR TITLE
Stable sort of model names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 .bundle
 .config
 .yardoc
-Gemfile.lock
 InstalledFiles
 _yardoc
 coverage

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,57 @@
+PATH
+  remote: .
+  specs:
+    schema_doc (0.0.2)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (6.0.3.2)
+      activesupport (= 6.0.3.2)
+    activerecord (6.0.3.2)
+      activemodel (= 6.0.3.2)
+      activesupport (= 6.0.3.2)
+    activesupport (6.0.3.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
+    concurrent-ruby (1.1.6)
+    diff-lcs (1.4.4)
+    i18n (1.8.3)
+      concurrent-ruby (~> 1.0)
+    minitest (5.14.1)
+    rake (13.0.1)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.3)
+    sqlite3 (1.4.2)
+    thread_safe (0.3.6)
+    tzinfo (1.2.7)
+      thread_safe (~> 0.1)
+    zeitwerk (2.3.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activerecord
+  bundler
+  rake (>= 3.2.16)
+  rspec
+  schema_doc!
+  sqlite3
+
+BUNDLED WITH
+   2.0.2

--- a/lib/schema_doc/document.rb
+++ b/lib/schema_doc/document.rb
@@ -7,7 +7,7 @@ module SchemaDoc
         document = []
 
         model_classes_group_by_table_name.sort.each do |table_name, model_classes|
-          document << table_document(table_name, model_classes)
+          document << table_document(table_name, model_classes.sort_by(&:name))
         end
 
         document.join

--- a/schema_doc.gemspec
+++ b/schema_doc.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", ">= 3.2.16"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "activerecord"

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -14,7 +14,7 @@ ActiveRecord::Base.establish_connection(
   'database' => dbfile
 )
 
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < ActiveRecord::Migration[6.0]
   def self.up
     create_table :users do |t|
       t.string  :nick
@@ -26,7 +26,7 @@ class CreateUsers < ActiveRecord::Migration
   end
 end
 
-class CreateBlogs < ActiveRecord::Migration
+class CreateBlogs < ActiveRecord::Migration[6.0]
   def self.up
     create_table :blogs do |t|
       t.string  :name
@@ -39,7 +39,7 @@ class CreateBlogs < ActiveRecord::Migration
   end
 end
 
-class CreateEntries < ActiveRecord::Migration
+class CreateEntries < ActiveRecord::Migration[6.0]
   def self.up
     create_table :entries do|t|
       t.string  :title

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -66,3 +66,7 @@ end
 class Entry < ActiveRecord::Base
   belongs_to :blog
 end
+
+class AnotherUser < ActiveRecord::Base
+  self.table_name = 'users'
+end

--- a/spec/schema_doc/document_spec.rb
+++ b/spec/schema_doc/document_spec.rb
@@ -1,6 +1,18 @@
 require 'helper'
 
 describe SchemaDoc::Document do
+  describe '.read' do
+    subject { described_class.read }
+    let(:blog) { subject.index('Blog') }
+    let(:user) { subject.index('User') }
+    let(:another_user) { subject.index('AnotherUser') }
+
+    it 'sorts by tables then model names' do
+      expect(another_user).to be < user
+      expect(blog).to be < another_user
+    end
+  end
+
   describe 'send(:table_document)' do
     let :document do
       SchemaDoc::Document.send(:table_document, *args)


### PR DESCRIPTION
Stabilizes document output by sorting the model names as well as table names.

Several other small housekeeping commits to get the project running:

- Add rails version to migrations for passing specs
- Include Gemfile.lock
- Relax bundler requirement
