### PR TITLE
Task/configurable model classes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    schema_doc (0.0.2)
+    schema_doc (0.0.3)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    schema_doc (0.0.3)
+    schema_doc (0.0.2)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ end
 
 SchemaDoc will output [THIS](https://github.com/mizoR/schema_doc/tree/master/example/sample_output.md).
 
+## Optional Configuration
+
+If you want to customize the models that are listed, you can create a `config/initializers/schema_doc.rb` as shown in the example below:
+
+```ruby
+SchemaDoc.configure do |config|
+  config.model_classes = Proc.new { ApplicationRecord.descendants.select{ |klass| klass.superclass.name == ApplicationRecord.name } }
+end
+```
+
 ## Contributing
 
 1. Fork it

--- a/lib/schema_doc.rb
+++ b/lib/schema_doc.rb
@@ -1,8 +1,25 @@
+require "schema_doc/configuration"
 require "schema_doc/version"
 require "schema_doc/document"
 require "schema_doc/railtie" if defined?(Rails)
 
 module SchemaDoc
+  class << self
+    attr_accessor :configuration
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.reset
+    @configuration = Configuration.new
+  end
+
+  def self.configure
+    yield(configuration)
+  end
+
   def self.root
     File.expand_path('../..', __FILE__)
   end

--- a/lib/schema_doc.rb
+++ b/lib/schema_doc.rb
@@ -1,25 +1,8 @@
-require "schema_doc/configuration"
 require "schema_doc/version"
 require "schema_doc/document"
 require "schema_doc/railtie" if defined?(Rails)
 
 module SchemaDoc
-  class << self
-    attr_accessor :configuration
-  end
-
-  def self.configuration
-    @configuration ||= Configuration.new
-  end
-
-  def self.reset
-    @configuration = Configuration.new
-  end
-
-  def self.configure
-    yield(configuration)
-  end
-
   def self.root
     File.expand_path('../..', __FILE__)
   end

--- a/lib/schema_doc/configuration.rb
+++ b/lib/schema_doc/configuration.rb
@@ -1,0 +1,9 @@
+module SchemaDoc
+  class Configuration
+    attr_accessor :model_classes
+    
+    def initialize
+      @model_classes = Proc.new { ActiveRecord::Base.descendants }
+    end
+  end
+end

--- a/lib/schema_doc/configuration.rb
+++ b/lib/schema_doc/configuration.rb
@@ -1,9 +1,0 @@
-module SchemaDoc
-  class Configuration
-    attr_accessor :model_classes
-    
-    def initialize
-      @model_classes = Proc.new { ActiveRecord::Base.descendants }
-    end
-  end
-end

--- a/lib/schema_doc/document.rb
+++ b/lib/schema_doc/document.rb
@@ -29,7 +29,7 @@ module SchemaDoc
       end
 
       def model_classes
-        ActiveRecord::Base.descendants
+        SchemaDoc.configuration.model_classes.try(:call)
       end
 
       def model_classes_group_by_table_name

--- a/lib/schema_doc/document.rb
+++ b/lib/schema_doc/document.rb
@@ -29,7 +29,7 @@ module SchemaDoc
       end
 
       def model_classes
-        SchemaDoc.configuration.model_classes.try(:call)
+        ActiveRecord::Base.descendants
       end
 
       def model_classes_group_by_table_name


### PR DESCRIPTION
Adds the ability to configure exactly which classes to include as part of `model_classes`

My project had too many STI classes so I wanted to skip those to keep the output readable without redundant tables/columns.
